### PR TITLE
awsへのデプロイ設定を追加修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 
 # CDK output directory
 cdk.out/
+# build file directory
+.dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+# CDK output directory
+cdk.out/

--- a/bin/hello-world.ts
+++ b/bin/hello-world.ts
@@ -4,5 +4,4 @@ import * as cdk from 'aws-cdk-lib';
 import { CdkHelloWorldStack } from '../src/lib/cdk-hello-world-stack';
 
 const app = new cdk.App();
-new CdkHelloWorldStack(app, 'CdkHelloWorldStack', {
-});
+new CdkHelloWorldStack(app);

--- a/cdk.json
+++ b/cdk.json
@@ -1,3 +1,8 @@
 {
-    "app": "npx ts-node bin/hello-world.ts"
+    "app": "npx ts-node bin/hello-world.ts",
+    "context": {
+        "account": "675693637283",
+        "region": "ap-northeast-1",
+        "stage": "dev"
+    }
 }

--- a/src/lib/cdk-hello-world-stack.ts
+++ b/src/lib/cdk-hello-world-stack.ts
@@ -4,8 +4,14 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 
 export class CdkHelloWorldStack extends cdk.Stack {
-    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
-      super(scope, id, props);
+    constructor(scope: Construct) {
+        const account: string = scope.node.tryGetContext('account');
+        const region: string = scope.node.tryGetContext('region');
+        const env = { account, region };
+        
+        const stage: string = scope.node.tryGetContext('stage');
+        const constructId = 'HelloWorld';
+        super(scope, `${stage}-${constructId}`, { env });
 
         const helloWorldFunction = new lambda.Function(this, 'HelloWorldFunction', {
           runtime: lambda.Runtime.NODEJS_20_X,

--- a/src/lib/cdk-hello-world-stack.ts
+++ b/src/lib/cdk-hello-world-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as path from 'path';
 
 export class CdkHelloWorldStack extends cdk.Stack {
     constructor(scope: Construct) {
@@ -13,9 +14,17 @@ export class CdkHelloWorldStack extends cdk.Stack {
         const constructId = 'HelloWorld';
         super(scope, `${stage}-${constructId}`, { env });
 
+        const rootDir = path.join(__dirname, '../../');
+        const distDir = path.join(rootDir, '.dist');
+
         const helloWorldFunction = new lambda.Function(this, 'HelloWorldFunction', {
           runtime: lambda.Runtime.NODEJS_20_X,
-          code: lambda.Code.fromAsset('lambda'),
+          code: lambda.Code.fromAsset(
+            path.join(
+              distDir,
+                'lambda'
+            )
+        ),
           handler: 'hello.handler',
         });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
+    "incremental": true, 
     "target": "ES2018",
     "module": "commonjs",
-    "outDir": "dist",
+    "outDir": "./.build",
     "rootDir": "./",
     "strict": true,
     "esModuleInterop": true

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,8 +11,6 @@ const ROOT_DIR = path.resolve(__dirname);
 const entry = { ...getEntries('lambda') };
 
 const config: Configuration = {
-  // CDK アプリのエントリーポイントを指定
-  // Todo　app.tsにかえる
   entry,
   output: {
     filename: '[name].js',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -2,12 +2,8 @@
 import * as path from 'path';
 import { Configuration } from 'webpack';
 import * as fs from 'fs';
-// const nodeExternals = require('webpack-node-externals');
-// const CopyPlugin = require('copy-webpack-plugin');
 
 const ROOT_DIR = path.resolve(__dirname);
-// const SRC_DIR = path.join(ROOT_DIR, 'src');
-
 const entry = { ...getEntries('lambda') };
 
 const config: Configuration = {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,13 +1,22 @@
+'use strict';
 import * as path from 'path';
 import { Configuration } from 'webpack';
+import * as fs from 'fs';
+// const nodeExternals = require('webpack-node-externals');
+// const CopyPlugin = require('copy-webpack-plugin');
+
+const ROOT_DIR = path.resolve(__dirname);
+// const SRC_DIR = path.join(ROOT_DIR, 'src');
+
+const entry = { ...getEntries('lambda') };
 
 const config: Configuration = {
   // CDK アプリのエントリーポイントを指定
   // Todo　app.tsにかえる
   entry: './bin/hello-world.ts',
   output: {
-    filename: 'hello-world.js',
-    path: path.resolve(__dirname, 'dist'),
+    filename: '[name].js',
+    path: path.resolve(ROOT_DIR, '.dist'),
     // CDK アプリは CommonJS モジュールとしてエクスポートされるため
     libraryTarget: 'commonjs2',
   },
@@ -35,3 +44,23 @@ const config: Configuration = {
 };
 
 export default config;
+
+function getEntries(dirname, entries = {}) {
+  const dirpath = path.join(ROOT_DIR, dirname);
+  const dirs = fs.readdirSync(dirpath, { withFileTypes: true });
+  const targets = dirs.filter(({ name }) => name !== 'base');
+
+  for (const dirent of targets) {
+      const { name } = dirent;
+
+      if (dirent.isDirectory()) {
+          Object.assign(entries, getEntries(path.join(dirname, name), entries));
+      }
+      if (dirent.isFile()) {
+          const nameWithoutExtension = name.split('.')[0];
+          entries[`${dirname}/${nameWithoutExtension}/index`] = path.join(dirpath, name);
+      }
+  }
+
+  return entries;
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,7 +13,7 @@ const entry = { ...getEntries('lambda') };
 const config: Configuration = {
   // CDK アプリのエントリーポイントを指定
   // Todo　app.tsにかえる
-  entry: './bin/hello-world.ts',
+  entry,
   output: {
     filename: '[name].js',
     path: path.resolve(ROOT_DIR, '.dist'),
@@ -45,7 +45,7 @@ const config: Configuration = {
 
 export default config;
 
-function getEntries(dirname, entries = {}) {
+function getEntries(dirname: string, entries: Record<string, string> = {}): {} {
   const dirpath = path.join(ROOT_DIR, dirname);
   const dirs = fs.readdirSync(dirpath, { withFileTypes: true });
   const targets = dirs.filter(({ name }) => name !== 'base');


### PR DESCRIPTION
## 変更内容

- タスクへのリンクは特にありません
- 概要
- awsへのデプロイ設定を追加修正
  - tsconfig.jsonの修正
  - webpack.config.tsの修正
  - lambdaの参照先パスの修正

## 検証方法
- Lmandaを叩いてみる
  - [Api Endpoint](https://z359gjsumf.execute-api.ap-northeast-1.amazonaws.com/prod/hello)

- 結果
以下の写真ようなレスポンスが帰ってくること
![スクリーンショット 2024-10-17 14 37 50](https://github.com/user-attachments/assets/fac03d91-6968-4ffa-a8e2-c9e413500f3b)


## 確認事項

- [x] lint 実施済み
- [x] テスト作成・実施済み


<!--
E2Eテスト実施時は以下も適用
- [ ] E2Eテスト作成・実施済み

```
テスト実行結果を貼り付ける（追加・変更した箇所のみで良い）
```
-->

## その他

<!--
対象外の作業など、レビュー時に必要な情報を記載
-->
