### PR TITLE
Cognitoとユーザプール作成

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -2,7 +2,6 @@
     "app": "npx ts-node bin/hello-world.ts",
     "context": {
         "account": "675693637283",
-        "region": "ap-northeast-1",
-        "stage": "dev"
+        "region": "ap-northeast-1"
     }
 }

--- a/src/lib/cdk-hello-world-stack.ts
+++ b/src/lib/cdk-hello-world-stack.ts
@@ -16,16 +16,15 @@ export class CdkHelloWorldStack extends cdk.Stack {
         super(scope, `${stage}-${constructId}`, { env });
 
         // 環境ごとのユーザープール名を取得
-        const environment = this.node.tryGetContext('env') || 'dev';
-        const userPoolName = `${environment}-userPool`;
+        const userPoolName = `${stage}-UserPool`;
 
         // ユーザープールの作成
-        const userPool = new cognito.UserPool(this, 'MyUserPool', {
+        const userPool = new cognito.UserPool(this, `${stage}-UserPool`, {
           userPoolName: userPoolName,
           signInAliases: {
-            email: true, // メールアドレスでサインイン可能
+            email: true,
           },
-          autoVerify: { // メールアドレスの自動確認
+          autoVerify: {
             email: true,
           },
           passwordPolicy: {
@@ -36,6 +35,7 @@ export class CdkHelloWorldStack extends cdk.Stack {
             requireDigits: true,
           },
         });
+       
 
         // ユーザープールクライアントの作成
         const userPoolClient = new cognito.UserPoolClient(this, 'MyUserPoolClient', {

--- a/src/lib/cdk-hello-world-stack.ts
+++ b/src/lib/cdk-hello-world-stack.ts
@@ -3,6 +3,7 @@ import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as path from 'path';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
 
 export class CdkHelloWorldStack extends cdk.Stack {
     constructor(scope: Construct) {
@@ -13,6 +14,47 @@ export class CdkHelloWorldStack extends cdk.Stack {
         const stage: string = scope.node.tryGetContext('stage');
         const constructId = 'HelloWorld';
         super(scope, `${stage}-${constructId}`, { env });
+
+        // 環境ごとのユーザープール名を取得
+        const environment = this.node.tryGetContext('env') || 'dev';
+        const userPoolName = `${environment}-userPool`;
+
+        // ユーザープールの作成
+        const userPool = new cognito.UserPool(this, 'MyUserPool', {
+          userPoolName: userPoolName,
+          signInAliases: {
+            email: true, // メールアドレスでサインイン可能
+          },
+          autoVerify: { // メールアドレスの自動確認
+            email: true,
+          },
+          passwordPolicy: {
+            minLength: 8,
+            requireSymbols: true,
+            requireUppercase: true,
+            requireLowercase: true,
+            requireDigits: true,
+          },
+        });
+
+        // ユーザープールクライアントの作成
+        const userPoolClient = new cognito.UserPoolClient(this, 'MyUserPoolClient', {
+          userPool,
+          authFlows: {
+            userPassword: true,
+          },
+        });
+
+        // 出力情報
+        new cdk.CfnOutput(this, 'UserPoolId', {
+          value: userPool.userPoolId,
+          description: 'The ID of the user pool',
+        });
+
+        new cdk.CfnOutput(this, 'UserPoolClientId', {
+          value: userPoolClient.userPoolClientId,
+          description: 'The client ID of the user pool client',
+        });
 
         const rootDir = path.join(__dirname, '../../');
         const distDir = path.join(rootDir, '.dist');


### PR DESCRIPTION
## 変更内容

- [タスクへのリンク]()はありません
- 概要
- Congitoを作成しました
- 環境ごとに作成できるようにしました

## 検証方法

- デプロイ時に作成されていること（aws configure が適切に設定されている必要があります）
```
npm ci && \
npm run build && \
cdk deploy --context stage=dev
```

- 結果
```
cdk deploy --context stage=dev   

✨  Synthesis time: 3.68s

Stack undefined
dev-HelloWorld: deploying... [1/1]
dev-HelloWorld: creating CloudFormation changeset...

 ✅  dev-HelloWorld (no changes)

✨  Deployment time: 1.23s

Outputs:
dev-HelloWorld.HelloWorldApiEndpointAD496187 = https://jeio2zdvrd.execute-api.ap-northeast-1.amazonaws.com/prod/
dev-HelloWorld.UserPoolClientId = 1gn5rp37s0knhe6rl02ueoqnmf
dev-HelloWorld.UserPoolId = ap-northeast-1_GIWd91qLO
Stack ARN:
arn:aws:cloudformation:ap-northeast-1:675693637283:stack/dev-HelloWorld/cd2cf742-8f70-11ef-8279-0ababf6f91c5

✨  Total time: 4.91s
```

<img width="1535" alt="スクリーンショット 2024-10-21 15 38 44" src="https://github.com/user-attachments/assets/0bd71b40-e03e-4537-99f0-aabbd5b8337e">


## 確認事項

- [x] lint 実施済み
- [x] テスト作成・実施済み


<!--
E2Eテスト実施時は以下も適用
- [ ] E2Eテスト作成・実施済み

```
テスト実行結果を貼り付ける（追加・変更した箇所のみで良い）
```
-->

## その他

<!--
対象外の作業など、レビュー時に必要な情報を記載
-->
