### PR TITLE
identityPoolId作成

### DIFF
--- a/aws-cdk/utils/constructs/userPool.ts
+++ b/aws-cdk/utils/constructs/userPool.ts
@@ -24,7 +24,10 @@ export class EnvironmentUserPool extends cognito.UserPool {
     // UserPoolClientの作成
     const userPoolClient = new cognito.UserPoolClient(scope, `${stackId}-UserPoolClient`, {
       userPool: this,
-      authFlows: { userPassword: true },
+      authFlows: {
+        userPassword: true,
+        userSrp: true,  // SRP 認証を有効にする
+      },
     });
 
     // Identity Poolの作成

--- a/aws-cdk/utils/constructs/userPool.ts
+++ b/aws-cdk/utils/constructs/userPool.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as cognito from "aws-cdk-lib/aws-cognito";
+import * as iam from "aws-cdk-lib/aws-iam"; // IAM モジュールをインポート
 import { Construct } from "constructs";
 
 export class EnvironmentUserPool extends cognito.UserPool {
@@ -41,11 +42,35 @@ export class EnvironmentUserPool extends cognito.UserPool {
       allowUnauthenticatedIdentities: false,
     });
 
+    // 環境ごとの IAM ロールを作成
+    const authenticatedRole = new iam.Role(scope, `${stackId}-AuthenticatedRole`, {
+      assumedBy: new iam.FederatedPrincipal(
+        'cognito-identity.amazonaws.com',
+        {
+          StringEquals: {
+            'cognito-identity.amazonaws.com:aud': identityPool.ref,
+          },
+          ForAnyValueEquals: {
+            'cognito-identity.amazonaws.com:amr': 'authenticated',
+          },
+        },
+        'sts:AssumeRoleWithWebIdentity',
+      ),
+    });
+
+    const lambdaAccessPolicy = new iam.PolicyStatement({
+      actions: ['lambda:InvokeFunction'],
+      resources: [`arn:aws:lambda:${cdk.Stack.of(scope).region}:${cdk.Stack.of(scope).account}:function:${stackId}-*`], // 環境ごとの Lambda 関数にアクセス
+    });
+
+    // IAM ロールにポリシーを追加
+    authenticatedRole.addToPolicy(lambdaAccessPolicy);
+
     // Cognito Identity PoolとCognito User Poolの関連付け
     new cognito.CfnIdentityPoolRoleAttachment(scope, `${stackId}-identityPoolRoleAttachment`, {
       identityPoolId: identityPool.ref,
       roles: {
-        authenticated: '',
+        authenticated: authenticatedRole.roleArn, // IAM ロールの ARN を指定
       },
     });
 

--- a/aws-cdk/utils/constructs/userPool.ts
+++ b/aws-cdk/utils/constructs/userPool.ts
@@ -34,6 +34,21 @@ export class EnvironmentUserPool extends cognito.UserPool {
       },
     });
 
+    // Identity Poolの作成
+    const identityPoolId = `${stackId}-identityPool`;
+    const identityPool = new cognito.CfnIdentityPool(scope, identityPoolId, {
+      identityPoolName: identityPoolId,
+      allowUnauthenticatedIdentities: false,
+    });
+
+    // Cognito Identity PoolとCognito User Poolの関連付け
+    new cognito.CfnIdentityPoolRoleAttachment(scope, `${stackId}-identityPoolRoleAttachment`, {
+      identityPoolId: identityPool.ref,
+      roles: {
+        authenticated: '',
+      },
+    });
+
     // 出力情報
     new cdk.CfnOutput(this, "UserPoolIdOutput", {
       value: this.userPoolId,
@@ -43,6 +58,11 @@ export class EnvironmentUserPool extends cognito.UserPool {
     new cdk.CfnOutput(this, "UserPoolClientIdOutput", {
       value: userPoolClient.userPoolClientId,
       description: `The client ID of the ${stackId} user pool client`,
+    });
+
+    new cdk.CfnOutput(this, "IdentityPoolIdOutput", {
+      value: identityPool.ref,
+      description: `The ID of the ${stackId} identity pool`,
     });
   }
 }

--- a/aws-cdk/utils/constructs/userPool.ts
+++ b/aws-cdk/utils/constructs/userPool.ts
@@ -10,8 +10,14 @@ export class EnvironmentUserPool extends cognito.UserPool {
     // UserPoolのコンストラクタを呼び出す
     super(scope, userPoolName, {
       userPoolName: userPoolName,
-      signInAliases: { email: true },
-      autoVerify: { email: true },
+      signInAliases: {
+        username: true,
+        email: true,
+        phone: false,
+      },
+      autoVerify: {
+        email: false,
+      },
       passwordPolicy: {
         minLength: 8,
         requireSymbols: true,


### PR DESCRIPTION
## 変更内容

- [タスクへのリンク]()
- 概要
- aws-amplifyでログインする際にidentityPoolIdを設定する必要があるため作成しました
- ユーザ作成の際にユーザ名を指定できるようにしました
- emailでのログインを可能セッティングしました

## 検証方法


- 実際に作成されていること
[AWSコンソール](https://ap-northeast-1.console.aws.amazon.com/cognito/v2/identity/identity-pools?region=ap-northeast-1)
<img width="933" alt="スクリーンショット 2024-11-18 16 32 12" src="https://github.com/user-attachments/assets/07f34dca-1448-43a8-be2a-18a6558312bd">

- ユーザープールにユーザを作成する際にユーザ名を指定できること
[ユーザ作成画面](https://ap-northeast-1.console.aws.amazon.com/cognito/v2/idp/user-pools/ap-northeast-1_Z0F1NdHfU/users/create/user?region=ap-northeast-1)

<img width="882" alt="スクリーンショット 2024-11-18 16 34 03" src="https://github.com/user-attachments/assets/315f4b4a-2695-4ddd-94f7-7605cd6592e8">

## 確認事項

- [ ] lint 実施済み
- [ ] テスト作成・実施済み


<!--
E2Eテスト実施時は以下も適用
- [ ] E2Eテスト作成・実施済み

```
テスト実行結果を貼り付ける（追加・変更した箇所のみで良い）
```
-->

## その他

<!--
対象外の作業など、レビュー時に必要な情報を記載
-->
